### PR TITLE
refactor: improve naming consistency and specify types

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ class MainCommand < CLI::Command
   end
 
   def run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Nil
-    msg = "Hello, #{arguments.get("name")}!"
+    message = "Hello, #{arguments.get("name")}!"
 
     if options.has? "caps"
-      puts msg.upcase
+      puts message.upcase
     else
-      puts msg
+      puts message
     end
   end
 end

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ dependencies:
 ```crystal
 require "cli"
 
-class MainCmd < CLI::Command
+class MainCommand < CLI::Command
   def setup : Nil
     @name = "greet"
     @description = "Greets a person"
-    add_argument "name", desc: "the name of the person to greet", required: true
-    add_option 'c', "caps", desc: "greet with capitals"
-    add_option 'h', "help", desc: "sends help information"
+    add_argument "name", description: "the name of the person to greet", required: true
+    add_option 'c', "caps", description: "greet with capitals"
+    add_option 'h', "help", description: "sends help information"
   end
 
-  def pre_run(args, options)
+  def pre_run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Bool
     if options.has? "help"
       puts help_template # generated using CLI::Formatter
 
@@ -38,8 +38,8 @@ class MainCmd < CLI::Command
     end
   end
 
-  def run(args, options) : Nil
-    msg = "Hello, #{args.get("name")}!"
+  def run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Nil
+    msg = "Hello, #{arguments.get("name")}!"
 
     if options.has? "caps"
       puts msg.upcase
@@ -49,7 +49,7 @@ class MainCmd < CLI::Command
   end
 end
 
-main = MainCmd.new
+main = MainCommand.new
 main.execute ARGV
 ```
 
@@ -77,17 +77,17 @@ HELLO, DEV!
 By default, the `Command` class is initialized with almost no values. All information about the command must be defined in the `setup` method.
 
 ```crystal
-class MainCmd < CLI::Command
+class MainCommand < CLI::Command
   def setup : Nil
     # prefer using `@name =` instead of `name =` to avoid method conflicts
     @name = "greet"
     # same here
     @description = "Greets a person"
     # defines an argument
-    add_argument "name", desc: "the name of the person to greet", required: true
+    add_argument "name", description: "the name of the person to greet", required: true
     # defines a flag option
-    add_option 'c', "caps", desc: "greet with capitals"
-    add_option 'h', "help", desc: "sends help information"
+    add_option 'c', "caps", description: "greet with capitals"
+    add_option 'h', "help", description: "sends help information"
   end
 end
 ```
@@ -98,11 +98,11 @@ Commands can also contain children, or subcommands:
 ```crystal
 require "cli"
 # import our subcommand here
-require "./welcome_cmd"
+require "./welcome_command"
 
-# using the `MainCmd` created earlier
-main = MainCmd.new
-main.add_command WelcomeCmd.new
+# using the `MainCommand` created earlier
+main = MainCommand.new
+main.add_command WelcomeCommand.new
 # there is also the `add_commands` method for adding multiple
 # subcommands at one time
 
@@ -130,8 +130,8 @@ Welcome to the CLI world, Dev!
 
 As well as being able to have subcommands, they can also inherit certain properties from the parent command:
 ```crystal
-# in welcome_cmd.cr ...
-class WelcomeCmd < CLI::Command
+# in welcome_command.cr ...
+class WelcomeCommand < CLI::Command
   def setup : Nil
     # ...
 
@@ -149,18 +149,18 @@ end
 
 Arguments and flag options can be defined in the `setup` method of a command using the `add_argument` and `add_option` methods respectively.
 ```crystal
-class MainCmd < CLI::Command
+class MainCommand < CLI::Command
   def setup : Nil
     add_argument "name",
       # sets a description for it
-      desc: "the name of the person to greet",
+      description: "the name of the person to greet",
       # set it as a required or optional argument
       required: true
 
     # define an option with a short flag using chars
     add_option 'c', "caps",
       # sets a description for it
-      desc: "greet with capitals",
+      description: "greet with capitals",
       # set it as a required or optional flag
       required: false,
       # set whether it should take a value
@@ -218,7 +218,7 @@ options = CLI::Formatter::Options.new option_delim: '+', show_defaults: false
 # we can re-use this in multiple commands
 formatter = CLI::Formatter.new options
 
-class MainCmd < CLI::Command
+class MainCommand < CLI::Command
   # ...
 
   def help_template : String

--- a/examples/greet/greet.cr
+++ b/examples/greet/greet.cr
@@ -1,16 +1,16 @@
 require "cli"
-require "./welcome_cmd"
+require "./welcome_command"
 
-class MainCmd < CLI::Command
+class MainCommand < CLI::Command
   def setup : Nil
     @name = "greet"
     @description = "Greets a person"
-    add_argument "name", desc: "the name of the person to greet", required: true
-    add_option 'c', "caps", desc: "greet with capitals"
-    add_option 'h', "help", desc: "sends help information"
+    add_argument "name", description: "the name of the person to greet", required: true
+    add_option 'c', "caps", description: "greet with capitals"
+    add_option 'h', "help", description: "sends help information"
   end
 
-  def pre_run(args, options)
+  def pre_run(arguments : ArgumentsInput, options : OptionsInput) : Bool
     if options.has? "help"
       puts help_template # generated using CLI::Formatter
 
@@ -20,8 +20,8 @@ class MainCmd < CLI::Command
     end
   end
 
-  def run(args, options) : Nil
-    msg = "Hello, #{args.get("name")}!"
+  def run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Nil
+    msg = "Hello, #{arguments.get("name")}!"
 
     if options.has? "caps"
       puts msg.upcase
@@ -31,7 +31,7 @@ class MainCmd < CLI::Command
   end
 end
 
-main = MainCmd.new
-main.add_command WelcomeCmd.new
+main = MainCommand.new
+main.add_command WelcomeCommand.new
 
 main.execute ARGV

--- a/examples/greet/greet.cr
+++ b/examples/greet/greet.cr
@@ -21,12 +21,12 @@ class MainCommand < CLI::Command
   end
 
   def run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Nil
-    msg = "Hello, #{arguments.get("name")}!"
+    message = "Hello, #{arguments.get("name")}!"
 
     if options.has? "caps"
-      puts msg.upcase
+      puts message.upcase
     else
-      puts msg
+      puts message
     end
   end
 end

--- a/examples/greet/welcome_command.cr
+++ b/examples/greet/welcome_command.cr
@@ -1,9 +1,9 @@
-class WelcomeCmd < CLI::Command
+class WelcomeCommand < CLI::Command
   def setup : Nil
     @name = "welcome"
     @summary = @description = "sends a friendly welcome message"
 
-    add_argument "name", desc: "the name of the person to greet", required: true
+    add_argument "name", description: "the name of the person to greet", required: true
     # this will inherit the header and footer properties
     inherit_borders = true
     # this will NOT inherit the parent flag options
@@ -12,7 +12,7 @@ class WelcomeCmd < CLI::Command
     inherit_streams = true
   end
 
-  def pre_run(args, options)
+  def pre_run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Bool
     if options.has? "help"
       puts help_template # generated using CLI::Formatter
 
@@ -22,7 +22,7 @@ class WelcomeCmd < CLI::Command
     end
   end
 
-  def run(args, options) : Nil
-    stdout.puts "Welcome to the CLI world, #{args.get("name")}!"
+  def run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Nil
+    stdout.puts "Welcome to the CLI world, #{arguments.get("name")}!"
   end
 end

--- a/spec/argument_spec.cr
+++ b/spec/argument_spec.cr
@@ -2,11 +2,11 @@ require "./spec_helper"
 
 describe CLI::Argument do
   it "parses an argument" do
-    arg = CLI::Argument.new "spec", "a test argument"
+    argument = CLI::Argument.new "spec", "a test argument"
 
-    arg.name.should eq "spec"
-    arg.description.should eq "a test argument"
-    arg.required?.should be_false
-    arg.value.should be_nil
+    argument.name.should eq "spec"
+    argument.description.should eq "a test argument"
+    argument.required?.should be_false
+    argument.value.should be_nil
   end
 end

--- a/spec/helper_spec.cr
+++ b/spec/helper_spec.cr
@@ -2,42 +2,42 @@ require "./spec_helper"
 
 # Inspired by Clim
 
-private class ContextCmd < CLI::Command
+private class ContextCommand < CLI::Command
   def setup : Nil
     @name = "context"
     @description = "Runs the Crystal context tool"
   end
 
-  def run(args, options) : Nil
+  def run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Nil
     stdout.puts "Fake crystal context command!"
   end
 end
 
-private class FormatCmd < CLI::Command
+private class FormatCommand < CLI::Command
   def setup : Nil
     @name = "format"
     @description = "Runs the Crystal format tool"
   end
 
-  def run(args, options) : Nil
+  def run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Nil
     stdout.puts "Fake crystal format command!"
   end
 end
 
-private class CrystalCmd < CLI::MainCommand
+private class CrystalCommand < CLI::MainCommand
   def setup : Nil
     super
 
     @description = "Runs some Crystal commands"
   end
 
-  def run(args, options) : Nil
+  def run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Nil
   end
 end
 
-command = CrystalCmd.new
-command.add_command ContextCmd.new
-command.add_command FormatCmd.new
+command = CrystalCommand.new
+command.add_command ContextCommand.new
+command.add_command FormatCommand.new
 
 describe CLI do
   it "prints the help message" do

--- a/spec/main_spec.cr
+++ b/spec/main_spec.cr
@@ -13,20 +13,20 @@ private class Greet < CLI::Command
     @name = "greet"
     @description = "Greets a person"
 
-    add_argument "name", desc: "the name of the person", required: true
-    add_option 'c', "caps", desc: "greet with caps"
+    add_argument "name", description: "the name of the person", required: true
+    add_option 'c', "caps", description: "greet with caps"
   end
 
-  def pre_run(args, options)
-    unless args.has? "name"
+  def pre_run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Bool?
+    unless arguments.has? "name"
       io.puts CLI::Formatter.new.generate self
 
       false
     end
   end
 
-  def run(args, options) : Nil
-    msg = %(Hello, #{args.get! "name"}!)
+  def run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Nil
+    msg = %(Hello, #{arguments.get! "name"}!)
 
     if options.has? "caps"
       io.puts msg.upcase
@@ -38,26 +38,26 @@ end
 
 describe CLI do
   it "tests the help command" do
-    cmd = Greet.new
-    cmd.execute %w()
+    command = Greet.new
+    command.execute %w()
 
-    cmd.io.to_s.should eq "Greets a person\n\n" \
-                          "Usage:\n\tgreet <arguments> [options]\n\n" \
-                          "Arguments:\n\tname    the name of the person (required)\n\n" \
-                          "Options:\n\t-c, --caps  greet with caps\n\n"
+    command.io.to_s.should eq "Greets a person\n\n" \
+                              "Usage:\n\tgreet <arguments> [options]\n\n" \
+                              "Arguments:\n\tname    the name of the person (required)\n\n" \
+                              "Options:\n\t-c, --caps  greet with caps\n\n"
   end
 
   it "tests the main command" do
-    cmd = Greet.new
-    cmd.execute %w(Dev)
+    command = Greet.new
+    command.execute %w(Dev)
 
-    cmd.io.to_s.should eq "Hello, Dev!\n"
+    command.io.to_s.should eq "Hello, Dev!\n"
   end
 
   it "tests the main command with flag" do
-    cmd = Greet.new
-    cmd.execute %w(-c Dev)
+    command = Greet.new
+    command.execute %w(-c Dev)
 
-    cmd.io.to_s.should eq "HELLO, DEV!\n"
+    command.io.to_s.should eq "HELLO, DEV!\n"
   end
 end

--- a/spec/main_spec.cr
+++ b/spec/main_spec.cr
@@ -26,12 +26,12 @@ private class Greet < CLI::Command
   end
 
   def run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Nil
-    msg = %(Hello, #{arguments.get! "name"}!)
+    message = %(Hello, #{arguments.get! "name"}!)
 
     if options.has? "caps"
-      io.puts msg.upcase
+      io.puts message.upcase
     else
-      io.puts msg
+      io.puts message
     end
   end
 end

--- a/spec/option_spec.cr
+++ b/spec/option_spec.cr
@@ -2,26 +2,26 @@ require "./spec_helper"
 
 describe CLI::Option do
   it "parses a long option" do
-    opt = CLI::Option.new "spec"
-    opt.long.should eq "spec"
-    opt.short.should be_nil
+    option = CLI::Option.new "spec"
+    option.long.should eq "spec"
+    option.short.should be_nil
 
-    opt.is?("spec").should be_true
+    option.is?("spec").should be_true
   end
 
   it "parses a short option" do
-    opt = CLI::Option.new "spec", 's'
-    opt.long.should eq "spec"
-    opt.short.should eq 's'
+    option = CLI::Option.new "spec", 's'
+    option.long.should eq "spec"
+    option.short.should eq 's'
 
-    opt.is?("s").should be_true
+    option.is?("s").should be_true
   end
 
   it "compares options" do
-    opt1 = CLI::Option.new "spec", 's'
-    opt2 = CLI::Option.new "flag", 'f'
+    option1 = CLI::Option.new "spec", 's'
+    option2 = CLI::Option.new "flag", 'f'
 
-    opt1.should_not eq opt2
-    opt1.should eq opt1.dup
+    option1.should_not eq option2
+    option1.should eq option1.dup
   end
 end

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -13,8 +13,8 @@ describe CLI::Parser do
   end
 
   it "parses custom flag input arguments" do
-    opts = CLI::Parser::Options.new option_delim: '+'
-    parser = CLI::Parser.new %(these ++are "some" +c arguments), opts
+    options = CLI::Parser::Options.new option_delim: '+'
+    parser = CLI::Parser.new %(these ++are "some" +c arguments), options
     results = parser.parse
 
     results[0].kind.should eq CLI::Parser::ResultKind::Argument

--- a/src/cli/argument.cr
+++ b/src/cli/argument.cr
@@ -31,28 +31,28 @@ module CLI
   end
 
   # An input structure to access validated arguments at execution time.
-  struct ArgsInput
-    getter args : Hash(String, Argument)
+  struct ArgumentsInput
+    getter arguments : Hash(String, Argument)
 
     # :nodoc:
-    def initialize(@args)
+    def initialize(@arguments)
     end
 
     # Indexes an argument by its name and returns the `Argument` object, not the argument's
     # value.
     def [](key : String) : Argument
-      @args[key]
+      @arguments[key]
     end
 
     # Indexes an argument by its name and returns the `Argument` object or `nil` if not found,
     # not the argument's value.
     def []?(key : String) : Argument?
-      @args[key]?
+      @arguments[key]?
     end
 
     # Returns `true` if an argument by the given name exists.
     def has?(key : String) : Bool
-      @args.has_key? key
+      @arguments.has_key? key
     end
 
     # Gets an argument by its name and returns its `Value`, or `nil` if not found.
@@ -67,12 +67,12 @@ module CLI
 
     # Returns `true` if there are no parsed arguments.
     def empty? : Bool
-      @args.empty?
+      @arguments.empty?
     end
 
     # Returns the number of parsed arguments.
     def size : Int32
-      @args.size
+      @arguments.size
     end
   end
 end

--- a/src/cli/command.cr
+++ b/src/cli/command.cr
@@ -25,7 +25,7 @@ module CLI
     getter children : Hash(String, Command)
 
     # A hash of arguments belonging to the command. These arguments are parsed at execution time
-    # and can be accessed in the `pre_run`, `run`, and `post_run` methods via `ArgsInput`.
+    # and can be accessed in the `pre_run`, `run`, and `post_run` methods via `ArgumentsInput`.
     getter arguments : Hash(String, Argument)
 
     # A hash of flag options belonging to the command. These options are parsed at execution time
@@ -146,21 +146,21 @@ module CLI
     end
 
     # Adds an argument to the command.
-    def add_argument(name : String, *, desc : String? = nil, required : Bool = false) : Nil
+    def add_argument(name : String, *, description : String? = nil, required : Bool = false) : Nil
       raise CommandError.new "Duplicate argument '#{name}'" if @arguments.has_key? name
-      @arguments[name] = Argument.new(name, desc, required)
+      @arguments[name] = Argument.new(name, description, required)
     end
 
     # Adds a long flag option to the command.
-    def add_option(long : String, *, desc : String? = nil, required : Bool = false,
+    def add_option(long : String, *, description : String? = nil, required : Bool = false,
                    has_value : Bool = false, default : Value::Type = nil) : Nil
       raise CommandError.new "Duplicate flag option '#{long}'" if @options.has_key? long
 
-      @options[long] = Option.new(long, nil, desc, required, has_value, default)
+      @options[long] = Option.new(long, nil, description, required, has_value, default)
     end
 
     # Adds a short flag option to the command.
-    def add_option(short : Char, long : String, *, desc : String? = nil, required : Bool = false,
+    def add_option(short : Char, long : String, *, description : String? = nil, required : Bool = false,
                    has_value : Bool = false, default : Value::Type = nil) : Nil
       raise CommandError.new "Duplicate flag option '#{long}'" if @options.has_key? long
 
@@ -168,7 +168,7 @@ module CLI
         raise CommandError.new "Flag '#{op.long}' already has the short option '#{short}'"
       end
 
-      @options[long] = Option.new(long, short, desc, required, has_value, default)
+      @options[long] = Option.new(long, short, description, required, has_value, default)
     end
 
     # Executes the command with the given input and parser (see `Parser`).
@@ -185,14 +185,14 @@ module CLI
     #
     # Accepts a `Bool` or `nil` argument as a return to specify whether the command should continue
     # to run once finished (`true` or `nil` to continue, `false` to stop).
-    def pre_run(args : ArgsInput, options : OptionsInput) : Bool?
+    def pre_run(arguments : ArgumentsInput, options : OptionsInput) : Bool?
     end
 
     # The main point of execution for the command, where arguments and options can be accessed.
-    abstract def run(args : ArgsInput, options : OptionsInput) : Nil
+    abstract def run(arguments : ArgumentsInput, options : OptionsInput) : Nil
 
     # A hook method to run once the `pre_run` and main `run` methods have been executed.
-    def post_run(args : ArgsInput, options : OptionsInput) : Nil
+    def post_run(arguments : ArgumentsInput, options : OptionsInput) : Nil
     end
 
     # A hook method for when the command raises an exception during execution. By default, this
@@ -203,14 +203,14 @@ module CLI
 
     # A hook method for when the command receives missing arguments during execution. By default,
     # this raises an `ArgumentError`.
-    def on_missing_arguments(args : Array(String))
-      raise CommandError.new %(Missing required argument#{"s" if args.size > 1}: #{args.join(", ")})
+    def on_missing_arguments(arguments : Array(String))
+      raise CommandError.new %(Missing required argument#{"s" if arguments.size > 1}: #{arguments.join(", ")})
     end
 
     # A hook method for when the command receives unknown arguments during execution. By default,
     # this raises an `ArgumentError`.
-    def on_unknown_arguments(args : Array(String))
-      raise CommandError.new %(Unknown argument#{"s" if args.size > 1}: #{args.join(", ")})
+    def on_unknown_arguments(arguments : Array(String))
+      raise CommandError.new %(Unknown argument#{"s" if arguments.size > 1}: #{arguments.join(", ")})
     end
 
     # A hook method for when the command receives missing options that are required during

--- a/src/cli/executor.cr
+++ b/src/cli/executor.cr
@@ -3,16 +3,16 @@
 # reason, most of the modules methods are hidden.
 module CLI::Executor
   private struct Result
-    getter parsed_opts : OptionsInput
-    getter unknown_opts : Array(String)
-    getter missing_opts : Array(String)
-    getter parsed_args : ArgsInput
-    getter unknown_args : Array(String)
-    getter missing_args : Array(String)
+    getter parsed_options : OptionsInput
+    getter unknown_options : Array(String)
+    getter missing_options : Array(String)
+    getter parsed_arguments : ArgumentsInput
+    getter unknown_arguments : Array(String)
+    getter missing_arguments : Array(String)
 
-    def initialize(parsed_opts, @unknown_opts, @missing_opts, parsed_args, @unknown_args, @missing_args)
-      @parsed_opts = OptionsInput.new parsed_opts
-      @parsed_args = ArgsInput.new parsed_args
+    def initialize(parsed_options, @unknown_options, @missing_options, parsed_arguments, @unknown_arguments, @missing_arguments)
+      @parsed_options = OptionsInput.new parsed_options
+      @parsed_arguments = ArgumentsInput.new parsed_arguments
     end
   end
 
@@ -35,41 +35,41 @@ module CLI::Executor
   # 5. The main `Command#run` and `Command#post_run` methods are executed with the evaluated
   # arguments and options.
   def self.handle(command : Command, results : Hash(Int32, Parser::Result)) : Nil
-    cmd = resolve_command command, pointerof(results)
-    unless cmd
+    resolved_command = resolve_command command, pointerof(results)
+    unless resolved_command
       command.on_error CommandError.new("Command '#{results.first[1].value}' not found")
       return
     end
 
-    executed = get_in_position cmd, results
+    executed = get_in_position resolved_command, results
 
     begin
-      res = cmd.pre_run executed.parsed_args, executed.parsed_opts
+      res = resolved_command.pre_run executed.parsed_arguments, executed.parsed_options
       unless res.nil?
         return unless res
       end
     rescue ex
-      cmd.on_error ex
+      resolved_command.on_error ex
     end
 
-    finalize cmd, executed
+    finalize resolved_command, executed
 
     begin
-      cmd.run executed.parsed_args, executed.parsed_opts
-      cmd.post_run executed.parsed_args, executed.parsed_opts
+      resolved_command.run executed.parsed_arguments, executed.parsed_options
+      resolved_command.post_run executed.parsed_arguments, executed.parsed_options
     rescue ex
-      cmd.on_error ex
+      resolved_command.on_error ex
     end
   end
 
-  private def self.resolve_command(command : Command, args : Hash(Int32, Parser::Result)*) : Command?
-    full_args = args.value.select { |_, v| v.kind.argument? && !v.string? }
-    return command if full_args.empty? || command.children.empty?
+  private def self.resolve_command(command : Command, arguments : Hash(Int32, Parser::Result)*) : Command?
+    full_arguments = arguments.value.select { |_, v| v.kind.argument? && !v.string? }
+    return command if full_arguments.empty? || command.children.empty?
 
-    key, res = full_args.first
-    if cmd = command.children.values.find &.is?(res.value)
-      args.value.delete key
-      resolve_command cmd, args
+    key, res = full_arguments.first
+    if found_command = command.children.values.find &.is?(res.value)
+      arguments.value.delete key
+      resolve_command found_command, arguments
     elsif !command.arguments.empty?
       command
     else
@@ -79,75 +79,75 @@ module CLI::Executor
 
   private def self.get_in_position(command : Command, results : Hash(Int32, Parser::Result)) : Result
     options = results.reject { |_, v| v.kind.argument? }
-    parsed_opts = {} of String => Option
-    unknown_opts = [] of String
+    parsed_options = {} of String => Option
+    unknown_options = [] of String
 
     options.each do |i, res|
-      if opt = command.options.values.find &.is? res.parse_value
-        if opt.has_value?
+      if option = command.options.values.find &.is? res.parse_value
+        if option.has_value?
           if res.value.includes? '='
-            opt.value = Value.new res.value.split('=', 2).last
-            parsed_opts[opt.long] = opt
+            option.value = Value.new res.value.split('=', 2).last
+            parsed_options[option.long] = option
           else
-            if arg = results[i + 1]?
-              if arg.kind.argument?
-                opt.value = Value.new arg.value
-                parsed_opts[opt.long] = opt
+            if argument = results[i + 1]?
+              if argument.kind.argument?
+                option.value = Value.new argument.value
+                parsed_options[option.long] = option
                 results.delete(i + 1)
                 next
               end
             end
 
-            raise ExecutionError.new "Missing argument for option '#{opt}'" unless opt.has_default?
-            opt.value = Value.new opt.default
-            parsed_opts[opt.long] = opt
+            raise ExecutionError.new "Missing argument for option '#{option}'" unless option.has_default?
+            option.value = Value.new option.default
+            parsed_options[option.long] = option
           end
         else
-          raise ExecutionError.new "Option '#{opt}' takes no arguments" if res.value.includes? '='
-          parsed_opts[opt.long] = opt
+          raise ExecutionError.new "Option '#{option}' takes no arguments" if res.value.includes? '='
+          parsed_options[option.long] = option
         end
       else
-        unknown_opts << res.parse_value
+        unknown_options << res.parse_value
       end
     end
 
-    default_opts = command.options
+    default_options = command.options
       .select { |_, v| v.has_default? }
-      .reject { |k, _| parsed_opts.has_key?(k) }
+      .reject { |k, _| parsed_options.has_key?(k) }
 
-    parsed_opts.merge! default_opts
-    missing_opts = command.options
+    parsed_options.merge! default_options
+    missing_options = command.options
       .select { |_, v| v.required? }
       .keys
-      .reject { |k| parsed_opts.has_key?(k) }
+      .reject { |k| parsed_options.has_key?(k) }
 
     arguments = results.values.select &.kind.argument?
-    parsed_args = {} of String => Argument
-    missing_args = [] of String
+    parsed_arguments = {} of String => Argument
+    missing_arguments = [] of String
 
-    command.arguments.values.each_with_index do |arg, i|
+    command.arguments.values.each_with_index do |argument, i|
       if res = arguments[i]?
-        arg.value = Value.new res.value
-        parsed_args[arg.name] = arg
+        argument.value = Value.new res.value
+        parsed_arguments[argument.name] = argument
         results.delete i
       else
-        missing_args << arg.name if arg.required?
+        missing_arguments << argument.name if argument.required?
       end
     end
 
-    unknown_args = if arguments.empty?
-                     [] of String
-                   else
-                     arguments[parsed_args.size...].map &.value
-                   end
+    unknown_arguments = if arguments.empty?
+                          [] of String
+                        else
+                          arguments[parsed_arguments.size...].map &.value
+                        end
 
-    Result.new(parsed_opts, unknown_opts, missing_opts, parsed_args, unknown_args, missing_args)
+    Result.new(parsed_options, unknown_options, missing_options, parsed_arguments, unknown_arguments, missing_arguments)
   end
 
   private def self.finalize(command : Command, res : Result) : Nil
-    command.on_unknown_options(res.unknown_opts) unless res.unknown_opts.empty?
-    command.on_missing_options(res.missing_opts) unless res.missing_opts.empty?
-    command.on_missing_arguments(res.missing_args) unless res.missing_args.empty?
-    command.on_unknown_arguments(res.unknown_args) unless res.unknown_args.empty?
+    command.on_unknown_options(res.unknown_options) unless res.unknown_options.empty?
+    command.on_missing_options(res.missing_options) unless res.missing_options.empty?
+    command.on_missing_arguments(res.missing_arguments) unless res.missing_arguments.empty?
+    command.on_unknown_arguments(res.unknown_arguments) unless res.unknown_arguments.empty?
   end
 end

--- a/src/cli/formatter.cr
+++ b/src/cli/formatter.cr
@@ -30,8 +30,8 @@ module CLI
           str << header << "\n\n"
         end
 
-        if desc = command.description
-          str << desc << "\n\n"
+        if description = command.description
+          str << description << "\n\n"
         end
 
         str << "Usage:"
@@ -84,10 +84,10 @@ module CLI
         str << "Commands:"
         max_space = commands.map(&.name.size).max + 4
 
-        commands.each do |cmd|
-          str << "\n\t" << cmd.name
-          str << " " * (max_space - cmd.name.size)
-          str << cmd.summary
+        commands.each do |command|
+          str << "\n\t" << command.name
+          str << " " * (max_space - command.name.size)
+          str << command.summary
         end
       end
     end
@@ -100,11 +100,11 @@ module CLI
         str << "Arguments:"
         max_space = command.arguments.keys.map(&.size).max + 4
 
-        command.arguments.each do |name, arg|
+        command.arguments.each do |name, argument|
           str << "\n\t" << name
           str << " " * (max_space - name.size)
-          str << arg.description
-          str << " (required)" if @options.show_required && arg.required?
+          str << argument.description
+          str << " (required)" if @options.show_required && argument.required?
         end
       end
     end
@@ -120,21 +120,21 @@ module CLI
         max_space = options.map { |o| 2 + o.long.size + (o.short ? 2 : 0) }.max + 2
 
         delim = @options.option_delim.to_s * 2
-        options.each do |opt|
-          name_size = 2 + opt.long.size + (opt.short ? 2 : -2)
+        options.each do |option|
+          name_size = 2 + option.long.size + (option.short ? 2 : -2)
 
           str << "\n\t"
-          if short = opt.short
+          if short = option.short
             str << delim[0] << short << ", "
           end
 
-          str << delim << opt.long
+          str << delim << option.long
           str << " " * (max_space - name_size)
-          str << opt.description
-          str << " (required)" if @options.show_required && opt.required?
+          str << option.description
+          str << " (required)" if @options.show_required && option.required?
 
           if @options.show_defaults
-            if opt.has_default? && (default = opt.default.to_s) && !default.blank?
+            if option.has_default? && (default = option.default.to_s) && !default.blank?
               str << " (default: " << default << ')'
             end
           end

--- a/src/cli/helper.cr
+++ b/src/cli/helper.cr
@@ -6,12 +6,12 @@ module CLI
       @inherit_borders = true
       @inherit_options = true
 
-      add_option 'h', "help", desc: "sends help information"
-      add_option 'v', "version", desc: "sends the app version"
+      add_option 'h', "help", description: "sends help information"
+      add_option 'v', "version", description: "sends the app version"
     end
 
-    def pre_run(args, options)
-      if args.empty? && options.empty?
+    def pre_run(arguments : CLI::ArgumentsInput, options : CLI::OptionsInput) : Bool
+      if arguments.empty? && options.empty?
         Formatter.new.generate(self).to_s(stdout)
         return false
       end

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -55,7 +55,7 @@ module CLI
     end
 
     def self.new(input : Array(String), options : Options = Options.new)
-      args = input.map do |a|
+      arguments = input.map do |a|
         if a.includes?(' ') && options.string_delims.none? { |d| a.includes?(d) }
           d = options.string_delims.first
           d.to_s + a + d.to_s
@@ -64,7 +64,7 @@ module CLI
         end
       end
 
-      new args.join(' '), options
+      new arguments.join(' '), options
     end
 
     # Parses the command line arguments from the reader and returns a hash of the results.
@@ -104,9 +104,9 @@ module CLI
         if res.parse_value.size > 1
           if res.value.includes? '='
             flags = res.parse_value.chars.map { |c| Result.new(:short_flag, c.to_s) }
-            opt = flags[-1]
-            opt.value += "=" + res.value.split('=', 2).last
-            flags[-1] = opt
+            option = flags[-1]
+            option.value += "=" + res.value.split('=', 2).last
+            flags[-1] = option
             validated += flags
           else
             validated += res.value.chars.map { |c| Result.new(:short_flag, c.to_s) }


### PR DESCRIPTION
Thanks for the awesome library!

This fixes inconsistent naming (`args` => `arguments`, `cmd` => `command`, `desc` => `description`, `msg` => `message`, `opts` => `options`) and adds explicit types to some method definitions.