### PR TITLE
fix(option): create value from default

### DIFF
--- a/src/cli/option.cr
+++ b/src/cli/option.cr
@@ -14,7 +14,7 @@ module CLI
 
     def initialize(@long : String, @short : Char? = nil, @description : String? = nil,
                    @required : Bool = false, @has_value : Bool = false, @default : Value::Type = nil)
-      @value = nil
+      @value = Value.new(@default)
     end
 
     # :inherit:


### PR DESCRIPTION
How to reproduce:

```cr
require "./src/cli"

class MainCmd < CLI::Command
  def setup : Nil
    add_option 'i', "input", default: "out", has_value: true, required: true
  end

  def run(args, options) : Nil
    pp options.get!("input")
  end
end

main = MainCmd.new
main.execute ARGV
```

Without the fix:

```
Unhandled exception: Nil assertion failed (NilAssertionError)
  from /usr/lib/crystal/nil.cr:108:5 in 'not_nil!'
  from src/cli/option.cr:85:7 in 'get!'
  from test.cr:12:8 in 'run'
  from src/cli/executor.cr:58:7 in 'handle'
  from src/cli/command.cr:178:7 in 'execute'
  from test.cr:17:1 in '__crystal_main'
  from /usr/lib/crystal/crystal/main.cr:115:5 in 'main_user_code'
  from /usr/lib/crystal/crystal/main.cr:101:7 in 'main'
  from /usr/lib/crystal/crystal/main.cr:127:3 in 'main'
  from /usr/lib/libc.so.6 in '??'
  from /usr/lib/libc.so.6 in '__libc_start_main'
  from ../sysdeps/x86_64/start.S:117 in '_start'
  from ???
```

With the fix:
```
CLI::Value(@raw="out")
```