### PR TITLE
refactor: new options system

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ By default, the `Command` class is initialized with almost no values. All inform
 ```crystal
 class MainCommand < CLI::Command
   def setup : Nil
-    # prefer using `@name =` instead of `name =` to avoid method conflicts
     @name = "greet"
-    # same here
     @description = "Greets a person"
     # defines an argument
     add_argument "name", description: "the name of the person to greet", required: true
@@ -136,11 +134,11 @@ class WelcomeCommand < CLI::Command
     # ...
 
     # this will inherit the header and footer properties
-    inherit_borders = true
+    @inherit_borders = true
     # this will NOT inherit the parent flag options
-    inherit_options = false
+    @inherit_options = false
     # this will inherit the input, output and error IO streams
-    inherit_streams = true
+    @inherit_streams = true
   end
 end
 ```
@@ -163,8 +161,11 @@ class MainCommand < CLI::Command
       description: "greet with capitals",
       # set it as a required or optional flag
       required: false,
-      # set whether it should take a value
-      has_value: false,
+      # the type of option it is, can be:
+      # :none to take no arguments
+      # :single to take one argument
+      # or :array to take multiple arguments
+      type: :none,
       # optionally set a default value
       default: nil
   end

--- a/shard.yml
+++ b/shard.yml
@@ -7,4 +7,7 @@ repository: https://github.com/devnote-dev/cli.cr
 authors:
   - Devonte W <https://github.com/devnote-dev>
 
+crystalline:
+  main: src/cli.cr
+
 license: MPL

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -5,11 +5,11 @@ describe CLI::Parser do
     parser = CLI::Parser.new %(these --are "some" -c arguments)
     results = parser.parse
 
-    results[0].kind.should eq CLI::Parser::ResultKind::Argument
-    results[1].kind.should eq CLI::Parser::ResultKind::LongFlag
-    results[2].kind.should eq CLI::Parser::ResultKind::Argument
-    results[3].kind.should eq CLI::Parser::ResultKind::ShortFlag
-    results[4].kind.should eq CLI::Parser::ResultKind::Argument
+    results[0].kind.should eq CLI::Parser::Result::Kind::Argument
+    results[1].kind.should eq CLI::Parser::Result::Kind::LongFlag
+    results[2].kind.should eq CLI::Parser::Result::Kind::Argument
+    results[3].kind.should eq CLI::Parser::Result::Kind::ShortFlag
+    results[4].kind.should eq CLI::Parser::Result::Kind::Argument
   end
 
   it "parses custom flag input arguments" do
@@ -17,33 +17,33 @@ describe CLI::Parser do
     parser = CLI::Parser.new %(these ++are "some" +c arguments), options
     results = parser.parse
 
-    results[0].kind.should eq CLI::Parser::ResultKind::Argument
-    results[1].kind.should eq CLI::Parser::ResultKind::LongFlag
-    results[2].kind.should eq CLI::Parser::ResultKind::Argument
-    results[3].kind.should eq CLI::Parser::ResultKind::ShortFlag
-    results[4].kind.should eq CLI::Parser::ResultKind::Argument
+    results[0].kind.should eq CLI::Parser::Result::Kind::Argument
+    results[1].kind.should eq CLI::Parser::Result::Kind::LongFlag
+    results[2].kind.should eq CLI::Parser::Result::Kind::Argument
+    results[3].kind.should eq CLI::Parser::Result::Kind::ShortFlag
+    results[4].kind.should eq CLI::Parser::Result::Kind::Argument
   end
 
   it "parses a string argument" do
     parser = CLI::Parser.new %(--test "string argument" -t)
     results = parser.parse
 
-    results[0].kind.should eq CLI::Parser::ResultKind::LongFlag
-    results[1].kind.should eq CLI::Parser::ResultKind::Argument
+    results[0].kind.should eq CLI::Parser::Result::Kind::LongFlag
+    results[1].kind.should eq CLI::Parser::Result::Kind::Argument
     results[1].value.should eq "string argument"
-    results[2].kind.should eq CLI::Parser::ResultKind::ShortFlag
+    results[2].kind.should eq CLI::Parser::Result::Kind::ShortFlag
   end
 
   it "parses an option argument" do
     parser = CLI::Parser.new %(--name=foo -k=bar)
     results = parser.parse
 
-    results[0].kind.should eq CLI::Parser::ResultKind::LongFlag
+    results[0].kind.should eq CLI::Parser::Result::Kind::LongFlag
     results[0].value.should eq "name=foo"
     results[0].parse_key.should eq "name"
     results[0].parse_value.should eq "foo"
 
-    results[1].kind.should eq CLI::Parser::ResultKind::ShortFlag
+    results[1].kind.should eq CLI::Parser::Result::Kind::ShortFlag
     results[1].value.should eq "k=bar"
     results[1].parse_key.should eq "k"
     results[1].parse_value.should eq "bar"

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -39,13 +39,24 @@ describe CLI::Parser do
     results = parser.parse
 
     results[0].kind.should eq CLI::Parser::Result::Kind::LongFlag
-    results[0].value.should eq "name=foo"
-    results[0].parse_key.should eq "name"
-    results[0].parse_value.should eq "foo"
+    results[0].key.should eq "name"
+    results[0].value.should eq "foo"
 
     results[1].kind.should eq CLI::Parser::Result::Kind::ShortFlag
-    results[1].value.should eq "k=bar"
-    results[1].parse_key.should eq "k"
-    results[1].parse_value.should eq "bar"
+    results[1].key.should eq "k"
+    results[1].value.should eq "bar"
+  end
+
+  it "parses an array argument" do
+    parser = CLI::Parser.new %(-n 1 -n=2 -n 3)
+    results = parser.parse
+
+    results[0].kind.should eq CLI::Parser::Result::Kind::ShortFlag
+    results[0].key.should eq "n"
+    results[0].value.should be_nil
+    results[1].value.should eq "1"
+    results[2].value.should eq "2"
+    results[3].value.should be_nil
+    results[4].value.should eq "3"
   end
 end

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -48,15 +48,17 @@ describe CLI::Parser do
   end
 
   it "parses an array argument" do
-    parser = CLI::Parser.new %(-n 1 -n=2 -n 3)
+    parser = CLI::Parser.new %(-n 1 -n=2,3 -n 4)
     results = parser.parse
 
     results[0].kind.should eq CLI::Parser::Result::Kind::ShortFlag
     results[0].key.should eq "n"
     results[0].value.should be_nil
     results[1].value.should eq "1"
-    results[2].value.should eq "2"
+    # This isn't managed by the parser so this is the raw value,
+    # the executor will parse this into ["2", "3"]
+    results[2].value.should eq "2,3"
     results[3].value.should be_nil
-    results[4].value.should eq "3"
+    results[4].value.should eq "4"
   end
 end

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -40,10 +40,12 @@ describe CLI::Parser do
 
     results[0].kind.should eq CLI::Parser::ResultKind::LongFlag
     results[0].value.should eq "name=foo"
-    results[0].parse_value.should eq "name"
+    results[0].parse_key.should eq "name"
+    results[0].parse_value.should eq "foo"
 
     results[1].kind.should eq CLI::Parser::ResultKind::ShortFlag
     results[1].value.should eq "k=bar"
-    results[1].parse_value.should eq "k"
+    results[1].parse_key.should eq "k"
+    results[1].parse_value.should eq "bar"
   end
 end

--- a/spec/value_spec.cr
+++ b/spec/value_spec.cr
@@ -7,9 +7,7 @@ describe CLI::Value do
     CLI::Value.new(4.56).should be_a CLI::Value
     CLI::Value.new(true).should be_a CLI::Value
     CLI::Value.new(nil).should be_a CLI::Value
-
-    # currently broken
-    # CLI::Value.new(%w[foo bar baz]).should be_a CLI::Value
+    CLI::Value.new(%w[foo bar baz]).should be_a CLI::Value
   end
 
   it "compares values" do
@@ -18,9 +16,7 @@ describe CLI::Value do
     CLI::Value.new(4.56).should eq 4.56
     CLI::Value.new(true).should eq true
     CLI::Value.new(nil).should eq nil
-
-    # also broken
-    # CLI::Value.new(%[foo bar baz]).should eq ["foo", "bar", "baz"]
+    CLI::Value.new(%w[foo bar baz]).should eq ["foo", "bar", "baz"]
   end
 
   it "asserts types" do
@@ -29,5 +25,6 @@ describe CLI::Value do
     CLI::Value.new(4.56).as_f64.should be_a Float64
     CLI::Value.new(true).as_bool.should be_true
     CLI::Value.new(nil).as_nil.should be_nil
+    CLI::Value.new(%w[]).as_a.should be_a Array(String)
   end
 end

--- a/src/cli/command.cr
+++ b/src/cli/command.cr
@@ -153,22 +153,22 @@ module CLI
 
     # Adds a long flag option to the command.
     def add_option(long : String, *, description : String? = nil, required : Bool = false,
-                   has_value : Bool = false, default : Value::Type = nil) : Nil
+                   type : Option::Type = :none, default : Value::Type = nil) : Nil
       raise CommandError.new "Duplicate flag option '#{long}'" if @options.has_key? long
 
-      @options[long] = Option.new(long, nil, description, required, has_value, default)
+      @options[long] = Option.new(long, nil, description, required, type, default)
     end
 
     # Adds a short flag option to the command.
     def add_option(short : Char, long : String, *, description : String? = nil, required : Bool = false,
-                   has_value : Bool = false, default : Value::Type = nil) : Nil
+                   type : Option::Type = :none, default : Value::Type = nil) : Nil
       raise CommandError.new "Duplicate flag option '#{long}'" if @options.has_key? long
 
       if op = @options.values.find { |o| o.short == short }
         raise CommandError.new "Flag '#{op.long}' already has the short option '#{short}'"
       end
 
-      @options[long] = Option.new(long, short, description, required, has_value, default)
+      @options[long] = Option.new(long, short, description, required, type, default)
     end
 
     # Executes the command with the given input and parser (see `Parser`).

--- a/src/cli/executor.cr
+++ b/src/cli/executor.cr
@@ -42,7 +42,6 @@ module CLI::Executor
     end
 
     executed = get_in_position resolved_command, results
-    puts results
 
     begin
       res = resolved_command.pre_run executed.parsed_arguments, executed.parsed_options

--- a/src/cli/executor.cr
+++ b/src/cli/executor.cr
@@ -10,7 +10,8 @@ module CLI::Executor
     getter unknown_arguments : Array(String)
     getter missing_arguments : Array(String)
 
-    def initialize(parsed_options, @unknown_options, @missing_options, parsed_arguments, @unknown_arguments, @missing_arguments)
+    def initialize(parsed_options, @unknown_options, @missing_options, parsed_arguments,
+                   @unknown_arguments, @missing_arguments)
       @parsed_options = OptionsInput.new parsed_options
       @parsed_arguments = ArgumentsInput.new parsed_arguments
     end
@@ -121,12 +122,6 @@ module CLI::Executor
 
     options.each do |key, value|
       option = command.options[key]
-      if option.type.none? && !value.raw.nil?
-        raise ExecutionError.new("Option '#{option}' takes no arguments")
-      elsif option.type.single? && value.raw.nil?
-        raise ExecutionError.new("Missing required argument for option '#{option}'")
-      end
-
       if option.type.none?
         raise ExecutionError.new("Option '#{option}' takes no arguments") unless value.raw.nil?
       else
@@ -135,7 +130,12 @@ module CLI::Executor
         end
 
         unless option.type.array? && value.raw.is_a? Array
-          value = Value.new [value.raw.to_s]
+          str = value.raw.to_s
+          value = if str.includes?(',')
+                    Value.new str.split(',', remove_empty: true)
+                  else
+                    Value.new [str]
+                  end
         end
       end
 

--- a/src/cli/executor.cr
+++ b/src/cli/executor.cr
@@ -88,12 +88,13 @@ module CLI::Executor
           raise ExecutionError.new("Option '#{option}' takes no arguments") if res.value.includes? '='
           parsed_options[option.long] = option
         else
-          if res.value.includes? '='
+          if res.value.includes?('=')
             option.value = if option.type.single?
-              Value.new res.parse_value
-            else
-              Value.new res.parse_value.split(',')
-            end
+                             Value.new res.parse_value
+                           else
+                             Value.new res.parse_value.split(',')
+                           end
+
             parsed_options[option.long] = option
           else
             if argument = results[i + 1]?
@@ -145,7 +146,14 @@ module CLI::Executor
                           arguments[parsed_arguments.size...].map &.value
                         end
 
-    Result.new(parsed_options, unknown_options, missing_options, parsed_arguments, unknown_arguments, missing_arguments)
+    Result.new(
+      parsed_options,
+      unknown_options,
+      missing_options,
+      parsed_arguments,
+      unknown_arguments,
+      missing_arguments
+    )
   end
 
   private def self.finalize(command : Command, res : Result) : Nil

--- a/src/cli/formatter.cr
+++ b/src/cli/formatter.cr
@@ -84,10 +84,10 @@ module CLI
         str << "Commands:"
         max_space = commands.map(&.name.size).max + 4
 
-        commands.each do |command|
-          str << "\n\t" << command.name
-          str << " " * (max_space - command.name.size)
-          str << command.summary
+        commands.each do |cmd|
+          str << "\n\t" << cmd.name
+          str << " " * (max_space - cmd.name.size)
+          str << cmd.summary
         end
       end
     end

--- a/src/cli/option.cr
+++ b/src/cli/option.cr
@@ -2,18 +2,24 @@ module CLI
   # Represents a command line flag option, supporting boolean and string values. Options are parsed
   # after the main command taking priority over the argument resolution (see `Executor#handle`).
   class Option
+    enum Type
+      None
+      Single
+      Array
+    end
+
     property long : String
     property short : Char?
     property description : String?
     property? required : Bool
-    getter? has_value : Bool
+    property type : Type
     property default : Value::Type
     property value : Value?
 
     def_equals @long, @short
 
     def initialize(@long : String, @short : Char? = nil, @description : String? = nil,
-                   @required : Bool = false, @has_value : Bool = false, @default : Value::Type = nil)
+                   @required : Bool = false, @type : Type = :none, @default : Value::Type = nil)
       @value = Value.new(@default)
     end
 

--- a/src/cli/option.cr
+++ b/src/cli/option.cr
@@ -2,6 +2,14 @@ module CLI
   # Represents a command line flag option, supporting boolean and string values. Options are parsed
   # after the main command taking priority over the argument resolution (see `Executor#handle`).
   class Option
+    # Identifies the value type of the option. `None` (the default) will not accept any arguments,
+    # `Single` will accept exactly 1 argument, and `Array` will accept multiple arguments. Array
+    # type options also support specifying the option name more than once in the command line:
+    #
+    # ```
+    # command argument --option=1,2,3 # allowed
+    # command argument -o 1 -o=2 -o 3 # also allowed
+    # ```
     enum Type
       None
       Single

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -77,7 +77,7 @@ module CLI
     end
 
     # Parses the command line arguments from the reader and returns a hash of the results.
-    def parse : Hash(Int32, Result)
+    def parse : Array(Result)
       results = [] of Result
 
       loop do
@@ -125,7 +125,7 @@ module CLI
         end
       end
 
-      validated.each_with_index.map { |r, i| {i, r} }.to_h
+      validated
     end
 
     private def read_option : Result

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -110,9 +110,9 @@ module CLI
           next
         end
 
-        if res.parse_value.size > 1
+        if res.parse_key.size > 1
           if res.value.includes? '='
-            flags = res.parse_value.chars.map { |c| Result.new(:short_flag, c.to_s) }
+            flags = res.parse_key.chars.map { |c| Result.new(:short_flag, c.to_s) }
             option = flags[-1]
             option.value += "=" + res.value.split('=', 2).last
             flags[-1] = option

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -37,10 +37,19 @@ module CLI
       def initialize(@kind, @value, *, @string = false)
       end
 
-      # Returns the key form of the value for flag results, or `value` for argument results.
-      def parse_value : String
+      # Returns the key form of the result for flag options, or `value` for argument results.
+      def parse_key : String
         if @value.includes? '='
           @value.split('=', 2).first
+        else
+          @value
+        end
+      end
+
+      # Returns the value form of the result for flag result options, or `value` for argument results.
+      def parse_value : String
+        if @value.includes? '='
+          @value.split('=', 2).last
         else
           @value
         end

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -20,17 +20,17 @@ module CLI
       end
     end
 
-    # Represents the kind of the result.
-    enum ResultKind
-      Argument
-      ShortFlag
-      LongFlag
-    end
-
     # The result of a parsed value from the command line. This can be a normal argument, string
     # argument, short flag, or long flag.
     class Result
-      property kind : ResultKind
+      # Represents the kind of the result.
+      enum Kind
+        Argument
+        ShortFlag
+        LongFlag
+      end
+
+      property kind : Kind
       property value : String
       getter? string : Bool
 
@@ -129,9 +129,9 @@ module CLI
     end
 
     private def read_option : Result
-      long = false
+      kind = Result::Kind::ShortFlag
       if @reader.peek_next_char == @options.option_delim
-        long = true
+        kind = Result::Kind::LongFlag
         @reader.pos += 2
       else
         @reader.next_char
@@ -156,7 +156,7 @@ module CLI
         end
       end
 
-      Result.new((long ? ResultKind::LongFlag : ResultKind::ShortFlag), value)
+      Result.new kind, value
     end
 
     private def read_argument : Result

--- a/src/cli/value.cr
+++ b/src/cli/value.cr
@@ -1,7 +1,7 @@
 module CLI
   # Represents a value for an argument or option.
   struct Value
-    alias Type = String | Number::Primitive | Bool | Nil # | Array(Type)
+    alias Type = String | Number::Primitive | Bool | Nil | Array(String)
 
     getter raw : Type
 

--- a/src/cli/value.cr
+++ b/src/cli/value.cr
@@ -27,7 +27,7 @@ module CLI
 
     # :inherit:
     def ==(other : Type) : Bool
-      @raw == other
+      @raw == other.raw
     end
 
     # Returns the value as a `String`.
@@ -65,8 +65,8 @@ module CLI
     end
 
     # Returns the value as an `Array`. Note that this does not change the type of the array.
-    def as_a : Array(Type)
-      @raw.as(Array)
+    def as_a : Array(String)
+      @raw.as(Array(String))
     end
 
     {% for base in %w(8 16 32 64 128) %}

--- a/src/cli/value.cr
+++ b/src/cli/value.cr
@@ -26,8 +26,13 @@ module CLI
     end
 
     # :inherit:
-    def ==(other : Type) : Bool
+    def ==(other : Value) : Bool
       @raw == other.raw
+    end
+
+    # :inherit:
+    def ==(other : Type) : Bool
+      @raw == other
     end
 
     # Returns the value as a `String`.


### PR DESCRIPTION
Changes the `CLI::Option` system to use a more readable/understandable format, using explicit `Option::Type`s to define the type of the option (what kind of arguments it can/should have), as well as support for array values including specifying an option multiple times from the input. Documentation has been updated accordingly for this, but more may be needed (TBD).